### PR TITLE
[RPS-200] Add Mysql config for Hippo

### DIFF
--- a/ansible/roles/service/hippo_authoring/files/rds_parameter_group.yml
+++ b/ansible/roles/service/hippo_authoring/files/rds_parameter_group.yml
@@ -1,0 +1,23 @@
+---
+
+Description: Hippo DB Config
+AWSTemplateFormatVersion: 2010-09-09
+
+Resources:
+
+  HippoMysqlConfig:
+    Type: "AWS::RDS::DBParameterGroup"
+    Properties:
+      Description: Hippo CMS Mysql config
+      Family: MySQL5.6
+      Parameters:
+        # to allow up to 100M file upload in CMS
+        innodb_log_file_size: 1572864000
+        max_allowed_packet: 157286400
+
+Outputs:
+  HippoMysqlConfig:
+    Description: Hippo CMS Mysql config
+    Export:
+      Name: !Sub "${AWS::StackName}::HippoMysqlConfig"
+    Value: !Ref HippoMysqlConfig

--- a/ansible/roles/service/hippo_authoring/tasks/main.yml
+++ b/ansible/roles/service/hippo_authoring/tasks/main.yml
@@ -1,5 +1,16 @@
 ---
 
+- name: Ensure Hippo Mysql Config
+  cloudformation:
+    stack_name: "{{ env }}-hippo-authoring-rds-parameters"
+    state: "{{ hippo_authoring.state }}"
+    template: "{{ role_path }}/files/rds_parameter_group.yml"
+    tags: "{{ aws.tags | combine({
+      'Role': role|replace('_', '-'),
+      'Description': 'Hippo Authoring RDS parameters',
+      'Name': env + '-' + role|replace('_', '-')
+    }) }}"
+
 - include_role:
     name: rds_mysql
   vars:

--- a/ansible/roles/service/rds_mysql/files/rds_mysql.yml
+++ b/ansible/roles/service/rds_mysql/files/rds_mysql.yml
@@ -89,6 +89,8 @@ Resources:
       BackupRetentionPeriod: !Ref BackupRetentionPeriod
       DBInstanceClass: !Ref InstanceType
       DBInstanceIdentifier: !Sub "${Environment}-${Role}"
+      DBParameterGroupName:
+        Fn::ImportValue: !Sub "${Environment}-hippo-authoring-rds-parameters::HippoMysqlConfig"
       DBSubnetGroupName: !Ref Subnet
       Engine: MySQL
       EngineVersion: !Ref Version


### PR DESCRIPTION
Added Hippo RDS parameter group with `innodb_log_file_size` and
`max_allowed_packet` to allow large (up to 100M) files upload.